### PR TITLE
Add Find by Dismissal Time

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -14,11 +14,12 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    // TODO
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    public static final String MESSAGE_NO_QUERY = "At least one valid field is required to find a student.";
 
     private final PredicateList predicates;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,21 +3,31 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_YEAR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FRIDAY_DISMISSAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MONDAY_DISMISSAL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_THURSDAY_DISMISSAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUESDAY_DISMISSAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_WEDNESDAY_DISMISSAL;
 
-import java.util.ArrayList;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.AcademicYearMatchesPredicate;
 import seedu.address.model.student.EmailContainsKeywordPredicate;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.PhoneMatchesPredicate;
 import seedu.address.model.student.PredicateList;
-import seedu.address.model.student.Student;
+import seedu.address.model.student.time.Day;
+import seedu.address.model.student.time.FridayDismissalPredicate;
+import seedu.address.model.student.time.MondayDismissalPredicate;
+import seedu.address.model.student.time.ThursdayDismissalPredicate;
+import seedu.address.model.student.time.TuesdayDismissalPredicate;
+import seedu.address.model.student.time.WednesdayDismissalPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -28,29 +38,72 @@ public class FindCommandParser implements Parser<FindCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      */
-    public FindCommand parse(String args) {
+    public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ACADEMIC_YEAR);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ACADEMIC_YEAR,
+                        PREFIX_MONDAY_DISMISSAL, PREFIX_TUESDAY_DISMISSAL, PREFIX_WEDNESDAY_DISMISSAL,
+                        PREFIX_THURSDAY_DISMISSAL, PREFIX_FRIDAY_DISMISSAL);
 
-        List<Predicate<Student>> predicates = new ArrayList<>();
+        PredicateList predicates = new PredicateList();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String words = argMultimap.getValue(PREFIX_NAME).get();
-            List<String> nameKeywords = Arrays.asList(words.split(" "));
-            predicates.add(new NameContainsKeywordsPredicate(nameKeywords));
+            String text = argMultimap.getValue(PREFIX_NAME).get();
+            predicates.add(new NameContainsKeywordsPredicate(getKeywordsFromString(text)));
         }
+
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             String phoneValue = argMultimap.getValue(PREFIX_PHONE).get();
             predicates.add(new PhoneMatchesPredicate(phoneValue));
         }
+
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             String keyword = argMultimap.getValue(PREFIX_EMAIL).get();
             predicates.add(new EmailContainsKeywordPredicate(keyword));
         }
+
         if (argMultimap.getValue(PREFIX_ACADEMIC_YEAR).isPresent()) {
             String academicYearValue = argMultimap.getValue(PREFIX_ACADEMIC_YEAR).get();
             predicates.add(new AcademicYearMatchesPredicate(academicYearValue));
         }
-        return new FindCommand(new PredicateList(predicates));
+
+        if (argMultimap.getValue(PREFIX_MONDAY_DISMISSAL).isPresent()) {
+            String timeString = argMultimap.getValue(PREFIX_MONDAY_DISMISSAL).get();
+            predicates.add(new MondayDismissalPredicate(getTimeFromString(timeString)));
+        }
+
+        if (argMultimap.getValue(PREFIX_TUESDAY_DISMISSAL).isPresent()) {
+            String timeString = argMultimap.getValue(PREFIX_TUESDAY_DISMISSAL).get();
+            predicates.add(new TuesdayDismissalPredicate(getTimeFromString(timeString)));
+        }
+
+        if (argMultimap.getValue(PREFIX_WEDNESDAY_DISMISSAL).isPresent()) {
+            String timeString = argMultimap.getValue(PREFIX_WEDNESDAY_DISMISSAL).get();
+            predicates.add(new WednesdayDismissalPredicate(getTimeFromString(timeString)));
+        }
+
+        if (argMultimap.getValue(PREFIX_THURSDAY_DISMISSAL).isPresent()) {
+            String timeString = argMultimap.getValue(PREFIX_THURSDAY_DISMISSAL).get();
+            predicates.add(new ThursdayDismissalPredicate(getTimeFromString(timeString)));
+        }
+
+        if (argMultimap.getValue(PREFIX_FRIDAY_DISMISSAL).isPresent()) {
+            String timeString = argMultimap.getValue(PREFIX_FRIDAY_DISMISSAL).get();
+            predicates.add(new FridayDismissalPredicate(getTimeFromString(timeString)));
+        }
+
+        if (predicates.isEmpty()) {
+            throw new ParseException(FindCommand.MESSAGE_NO_QUERY);
+        }
+
+        return new FindCommand(predicates);
+    }
+
+    private List<String> getKeywordsFromString(String str) {
+        return Arrays.asList(str.split(" "));
+    }
+
+    private LocalTime getTimeFromString(String str) throws ParseException {
+        Day day = ParserUtil.parseDismissal(Day.DayOfWeek.MONDAY, str);
+        return day.dismissalTime;
     }
 }

--- a/src/main/java/seedu/address/model/student/PredicateList.java
+++ b/src/main/java/seedu/address/model/student/PredicateList.java
@@ -1,5 +1,6 @@
 package seedu.address.model.student;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -17,6 +18,11 @@ public class PredicateList implements Predicate<Student> {
 
     public PredicateList() {
         predicates = new LinkedList<>();
+    }
+
+    @SafeVarargs
+    public static PredicateList of(Predicate<Student>... predicates) {
+        return new PredicateList(Arrays.asList(predicates));
     }
 
     public boolean add(Predicate<Student> predicate) {

--- a/src/main/java/seedu/address/model/student/PredicateList.java
+++ b/src/main/java/seedu/address/model/student/PredicateList.java
@@ -1,10 +1,12 @@
 package seedu.address.model.student;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
 
 /**
- * Tests that a {@code Student}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Student}'s parameters match all the predicates in the predicate list.
+ * If the predicate list is empty, it defaults to false.
  */
 public class PredicateList implements Predicate<Student> {
     private final List<Predicate<Student>> predicates;
@@ -13,8 +15,23 @@ public class PredicateList implements Predicate<Student> {
         this.predicates = predicates;
     }
 
+    public PredicateList() {
+        predicates = new LinkedList<>();
+    }
+
+    public boolean add(Predicate<Student> predicate) {
+        return predicates.add(predicate);
+    }
+
+    public boolean isEmpty() {
+        return predicates.isEmpty();
+    }
+
     @Override
     public boolean test(Student student) {
+        if (predicates.isEmpty()) {
+            return false;
+        }
         return predicates.stream()
                 .allMatch(p -> p.test(student));
     }

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -86,7 +86,6 @@ public class Student {
 
     public AcademicYear getAcademicYear() {
         return academicYear;
-
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/time/FridayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/FridayDismissalPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.student.time;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s dismissal time for Friday is before the query time.
+ */
+public class FridayDismissalPredicate implements Predicate<Student> {
+    private final LocalTime queryTime;
+
+    public FridayDismissalPredicate(LocalTime queryTime) {
+        this.queryTime = queryTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getFridayDismissal().dismissalTime.isBefore(queryTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FridayDismissalPredicate // instanceof handles nulls
+                && queryTime.equals(((FridayDismissalPredicate) other).queryTime)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/student/time/FridayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/FridayDismissalPredicate.java
@@ -17,7 +17,8 @@ public class FridayDismissalPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return student.getFridayDismissal().dismissalTime.isBefore(queryTime);
+        LocalTime studentTime = student.getFridayDismissal().dismissalTime;
+        return studentTime.equals(queryTime) || studentTime.isBefore(queryTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/time/MondayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/MondayDismissalPredicate.java
@@ -17,7 +17,8 @@ public class MondayDismissalPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return student.getMondayDismissal().dismissalTime.isBefore(queryTime);
+        LocalTime studentTime = student.getMondayDismissal().dismissalTime;
+        return studentTime.equals(queryTime) || studentTime.isBefore(queryTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/time/MondayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/MondayDismissalPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.student.time;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s dismissal time for Monday is before the query time.
+ */
+public class MondayDismissalPredicate implements Predicate<Student> {
+    private final LocalTime queryTime;
+
+    public MondayDismissalPredicate(LocalTime queryTime) {
+        this.queryTime = queryTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getMondayDismissal().dismissalTime.isBefore(queryTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof MondayDismissalPredicate // instanceof handles nulls
+                && queryTime.equals(((MondayDismissalPredicate) other).queryTime)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/student/time/ThursdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/ThursdayDismissalPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.student.time;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s dismissal time for Thursday is before the query time.
+ */
+public class ThursdayDismissalPredicate implements Predicate<Student> {
+    private final LocalTime queryTime;
+
+    public ThursdayDismissalPredicate(LocalTime queryTime) {
+        this.queryTime = queryTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getThursdayDismissal().dismissalTime.isBefore(queryTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ThursdayDismissalPredicate // instanceof handles nulls
+                && queryTime.equals(((ThursdayDismissalPredicate) other).queryTime)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/student/time/ThursdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/ThursdayDismissalPredicate.java
@@ -17,7 +17,8 @@ public class ThursdayDismissalPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return student.getThursdayDismissal().dismissalTime.isBefore(queryTime);
+        LocalTime studentTime = student.getThursdayDismissal().dismissalTime;
+        return studentTime.equals(queryTime) || studentTime.isBefore(queryTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/time/TuesdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/TuesdayDismissalPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.student.time;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s dismissal time for Tuesday is before the query time.
+ */
+public class TuesdayDismissalPredicate implements Predicate<Student> {
+    private final LocalTime queryTime;
+
+    public TuesdayDismissalPredicate(LocalTime queryTime) {
+        this.queryTime = queryTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getTuesdayDismissal().dismissalTime.isBefore(queryTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TuesdayDismissalPredicate // instanceof handles nulls
+                && queryTime.equals(((TuesdayDismissalPredicate) other).queryTime)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/student/time/TuesdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/TuesdayDismissalPredicate.java
@@ -17,7 +17,8 @@ public class TuesdayDismissalPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return student.getTuesdayDismissal().dismissalTime.isBefore(queryTime);
+        LocalTime studentTime = student.getTuesdayDismissal().dismissalTime;
+        return studentTime.equals(queryTime) || studentTime.isBefore(queryTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/time/WednesdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/WednesdayDismissalPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.student.time;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s dismissal time for Wednesday is before the query time.
+ */
+public class WednesdayDismissalPredicate implements Predicate<Student> {
+    private final LocalTime queryTime;
+
+    public WednesdayDismissalPredicate(LocalTime queryTime) {
+        this.queryTime = queryTime;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getWednesdayDismissal().dismissalTime.isBefore(queryTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof WednesdayDismissalPredicate // instanceof handles nulls
+                && queryTime.equals(((WednesdayDismissalPredicate) other).queryTime)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/student/time/WednesdayDismissalPredicate.java
+++ b/src/main/java/seedu/address/model/student/time/WednesdayDismissalPredicate.java
@@ -17,7 +17,8 @@ public class WednesdayDismissalPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        return student.getWednesdayDismissal().dismissalTime.isBefore(queryTime);
+        LocalTime studentTime = student.getWednesdayDismissal().dismissalTime;
+        return studentTime.equals(queryTime) || studentTime.isBefore(queryTime);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.PhoneMatchesPredicate;
 import seedu.address.model.student.PredicateList;
+import seedu.address.model.student.time.Day;
 
 public class FindCommandParserTest {
 
@@ -19,17 +21,41 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand firstExpectedFindCommand =
-                new FindCommand(new PredicateList(Arrays.asList(
+                new FindCommand(PredicateList.of(
                         new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new PhoneMatchesPredicate("123456"))));
+                        new PhoneMatchesPredicate("123456")
+                ));
         assertParseSuccess(parser, " n/Alice Bob p/123456", firstExpectedFindCommand);
 
         // multiple whitespaces between keywords
         FindCommand secondExpectedFindCommand =
-                new FindCommand(new PredicateList(Arrays.asList(
-                        new NameContainsKeywordsPredicate(Arrays.asList("Alice")),
-                        new PhoneMatchesPredicate("85355255"))));
-        assertParseSuccess(parser, "  \n  \t n/Alice \t \n \n p/85355255", secondExpectedFindCommand);
+                new FindCommand(PredicateList.of(
+                        new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        new PhoneMatchesPredicate("85355255")
+                ));
+        assertParseSuccess(parser, "  \n  \t n/Alice Bob \t \n \n p/85355255", secondExpectedFindCommand);
     }
 
+    @Test
+    public void parse_noQuery_failure() {
+        assertParseFailure(parser, " ", FindCommand.MESSAGE_NO_QUERY);
+    }
+
+    @Test
+    public void parse_invalidTime_failure() {
+        assertParseFailure(parser, " d1/423", Day.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validTimeFollowedByInvalidTime_failure() {
+        assertParseFailure(parser, " d1/0800 d2/432", Day.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        FindCommand expectedFindCommand = new FindCommand(PredicateList.of(
+                new PhoneMatchesPredicate("33333333")
+        ));
+        assertParseSuccess(parser, " p/11111111 p/22222222 p/33333333", expectedFindCommand);
+    }
 }

--- a/src/test/java/seedu/address/model/student/AcademicYearMatchesPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/AcademicYearMatchesPredicateTest.java
@@ -1,0 +1,49 @@
+package seedu.address.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.StudentBuilder;
+
+class AcademicYearMatchesPredicateTest {
+
+    @Test
+    void equals() {
+        String firstYear = "1";
+        String secondYear = "2";
+
+        AcademicYearMatchesPredicate firstPredicate = new AcademicYearMatchesPredicate(firstYear);
+        AcademicYearMatchesPredicate secondPredicate = new AcademicYearMatchesPredicate(secondYear);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AcademicYearMatchesPredicate firstPredicateCopy = new AcademicYearMatchesPredicate(firstYear);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different academic year -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    void test_yearMatches_returnsTrue() {
+        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate("3");
+        assertTrue(predicate.test(new StudentBuilder().withAcademicYear("3").build()));
+    }
+
+    @Test
+    void test_yearDoesNotMatch_returnsFalse() {
+        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate("3");
+        assertFalse(predicate.test(new StudentBuilder().withAcademicYear("1").build()));
+        assertFalse(predicate.test(new StudentBuilder().withAcademicYear("2").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
@@ -1,2 +1,269 @@
-package seedu.address.model.student;public class DayDismissalTimePredicateTest {
+package seedu.address.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.student.time.Day;
+import seedu.address.model.student.time.FridayDismissalPredicate;
+import seedu.address.model.student.time.MondayDismissalPredicate;
+import seedu.address.model.student.time.ThursdayDismissalPredicate;
+import seedu.address.model.student.time.TuesdayDismissalPredicate;
+import seedu.address.model.student.time.WednesdayDismissalPredicate;
+import seedu.address.testutil.StudentBuilder;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class DayDismissalPredicateTest {
+    public String timePattern = "HHmm";
+
+    @Test
+    public void equalsMonday() {
+        String firstTime = "1240";
+        String secondTime = "1500";
+
+        MondayDismissalPredicate firstPredicate= new MondayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        MondayDismissalPredicate secondPredicate = new MondayDismissalPredicate(
+                LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        MondayDismissalPredicate firstPredicateCopy = new MondayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different phone number -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void equalsTuesday() {
+        String firstTime = "1240";
+        String secondTime = "1500";
+
+        TuesdayDismissalPredicate firstPredicate= new TuesdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        TuesdayDismissalPredicate secondPredicate = new TuesdayDismissalPredicate(
+                LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TuesdayDismissalPredicate firstPredicateCopy = new TuesdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different phone number -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void equalsWednesday() {
+        String firstTime = "1240";
+        String secondTime = "1500";
+
+        WednesdayDismissalPredicate firstPredicate= new WednesdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        WednesdayDismissalPredicate secondPredicate = new WednesdayDismissalPredicate(
+                LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        WednesdayDismissalPredicate firstPredicateCopy = new WednesdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different phone number -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void equalsThursday() {
+        String firstTime = "1240";
+        String secondTime = "1500";
+
+        ThursdayDismissalPredicate firstPredicate= new ThursdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        ThursdayDismissalPredicate secondPredicate = new ThursdayDismissalPredicate(
+                LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ThursdayDismissalPredicate firstPredicateCopy = new ThursdayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different phone number -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void equalsFriday() {
+        String firstTime = "1240";
+        String secondTime = "1500";
+
+        FridayDismissalPredicate firstPredicate= new FridayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        FridayDismissalPredicate secondPredicate = new FridayDismissalPredicate(
+                LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        FridayDismissalPredicate firstPredicateCopy = new FridayDismissalPredicate(
+                LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different phone number -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_equalDismissalTime_returnsTrue() {
+        String subjectTime = "1500";
+        String queryTime = "1500";
+
+        // Monday
+        Day monday = new Day(queryTime);
+        assertTrue(new MondayDismissalPredicate(monday.dismissalTime).test(
+                new StudentBuilder().withMondayDismissal(subjectTime).build()
+        ));
+
+        // Tuesday
+        Day tuesday = new Day(queryTime);
+        assertTrue(new TuesdayDismissalPredicate(tuesday.dismissalTime).test(
+                new StudentBuilder().withTuesdayDismissal(subjectTime).build()
+        ));
+
+        // Wednesday
+        Day wednesday = new Day(queryTime);
+        assertTrue(new WednesdayDismissalPredicate(wednesday.dismissalTime).test(
+                new StudentBuilder().withWednesdayDismissal(subjectTime).build()
+        ));
+
+        // Thursday
+        Day thursday= new Day(queryTime);
+        assertTrue(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
+                new StudentBuilder().withThursdayDismissal(subjectTime).build()
+        ));
+
+        // Friday
+        Day friday = new Day(queryTime);
+        assertTrue(new FridayDismissalPredicate(friday.dismissalTime).test(
+                new StudentBuilder().withFridayDismissal(subjectTime).build()
+        ));
+    }
+
+    @Test
+    public void test_queryAfterSubjectDismissalTime_returnsTrue() {
+        String subjectTime = "1500";
+        String queryTime = "1501";
+
+        // Monday
+        Day monday = new Day(queryTime);
+        assertTrue(new MondayDismissalPredicate(monday.dismissalTime).test(
+                new StudentBuilder().withMondayDismissal(subjectTime).build()
+        ));
+
+        // Tuesday
+        Day tuesday = new Day(queryTime);
+        assertTrue(new TuesdayDismissalPredicate(tuesday.dismissalTime).test(
+                new StudentBuilder().withTuesdayDismissal(subjectTime).build()
+        ));
+
+        // Wednesday
+        Day wednesday = new Day(queryTime);
+        assertTrue(new WednesdayDismissalPredicate(wednesday.dismissalTime).test(
+                new StudentBuilder().withWednesdayDismissal(subjectTime).build()
+        ));
+
+        // Thursday
+        Day thursday= new Day(queryTime);
+        assertTrue(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
+                new StudentBuilder().withThursdayDismissal(subjectTime).build()
+        ));
+
+        // Friday
+        Day friday = new Day(queryTime);
+        assertTrue(new FridayDismissalPredicate(friday.dismissalTime).test(
+                new StudentBuilder().withFridayDismissal(subjectTime).build()
+        ));
+    }
+
+    @Test
+    public void test_queryBeforeSubjectDismissalTime_returnsFalse() {
+        String subjectTime = "1500";
+        String queryTime = "1459";
+
+        // Monday
+        Day monday = new Day(queryTime);
+        assertFalse(new MondayDismissalPredicate(monday.dismissalTime).test(
+                new StudentBuilder().withMondayDismissal(subjectTime).build()
+        ));
+
+        // Tuesday
+        Day tuesday = new Day(queryTime);
+        assertFalse(new TuesdayDismissalPredicate(tuesday.dismissalTime).test(
+                new StudentBuilder().withTuesdayDismissal(subjectTime).build()
+        ));
+
+        // Wednesday
+        Day wednesday = new Day(queryTime);
+        assertFalse(new WednesdayDismissalPredicate(wednesday.dismissalTime).test(
+                new StudentBuilder().withWednesdayDismissal(subjectTime).build()
+        ));
+
+        // Thursday
+        Day thursday= new Day(queryTime);
+        assertFalse(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
+                new StudentBuilder().withThursdayDismissal(subjectTime).build()
+        ));
+
+        // Friday
+        Day friday = new Day(queryTime);
+        assertFalse(new FridayDismissalPredicate(friday.dismissalTime).test(
+                new StudentBuilder().withFridayDismissal(subjectTime).build()
+        ));
+    }
 }

--- a/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
@@ -1,0 +1,2 @@
+package seedu.address.model.student;public class DayDismissalTimePredicateTest {
+}

--- a/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/DayDismissalPredicateTest.java
@@ -3,6 +3,9 @@ package seedu.address.model.student;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.student.time.Day;
@@ -13,18 +16,15 @@ import seedu.address.model.student.time.TuesdayDismissalPredicate;
 import seedu.address.model.student.time.WednesdayDismissalPredicate;
 import seedu.address.testutil.StudentBuilder;
 
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-
 public class DayDismissalPredicateTest {
-    public String timePattern = "HHmm";
+    private String timePattern = "HHmm";
 
     @Test
     public void equalsMonday() {
         String firstTime = "1240";
         String secondTime = "1500";
 
-        MondayDismissalPredicate firstPredicate= new MondayDismissalPredicate(
+        MondayDismissalPredicate firstPredicate = new MondayDismissalPredicate(
                 LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
         MondayDismissalPredicate secondPredicate = new MondayDismissalPredicate(
                 LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
@@ -52,7 +52,7 @@ public class DayDismissalPredicateTest {
         String firstTime = "1240";
         String secondTime = "1500";
 
-        TuesdayDismissalPredicate firstPredicate= new TuesdayDismissalPredicate(
+        TuesdayDismissalPredicate firstPredicate = new TuesdayDismissalPredicate(
                 LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
         TuesdayDismissalPredicate secondPredicate = new TuesdayDismissalPredicate(
                 LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
@@ -80,7 +80,7 @@ public class DayDismissalPredicateTest {
         String firstTime = "1240";
         String secondTime = "1500";
 
-        WednesdayDismissalPredicate firstPredicate= new WednesdayDismissalPredicate(
+        WednesdayDismissalPredicate firstPredicate = new WednesdayDismissalPredicate(
                 LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
         WednesdayDismissalPredicate secondPredicate = new WednesdayDismissalPredicate(
                 LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
@@ -108,7 +108,7 @@ public class DayDismissalPredicateTest {
         String firstTime = "1240";
         String secondTime = "1500";
 
-        ThursdayDismissalPredicate firstPredicate= new ThursdayDismissalPredicate(
+        ThursdayDismissalPredicate firstPredicate = new ThursdayDismissalPredicate(
                 LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
         ThursdayDismissalPredicate secondPredicate = new ThursdayDismissalPredicate(
                 LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
@@ -136,7 +136,7 @@ public class DayDismissalPredicateTest {
         String firstTime = "1240";
         String secondTime = "1500";
 
-        FridayDismissalPredicate firstPredicate= new FridayDismissalPredicate(
+        FridayDismissalPredicate firstPredicate = new FridayDismissalPredicate(
                 LocalTime.parse(firstTime, DateTimeFormatter.ofPattern(timePattern)));
         FridayDismissalPredicate secondPredicate = new FridayDismissalPredicate(
                 LocalTime.parse(secondTime, DateTimeFormatter.ofPattern(timePattern)));
@@ -183,7 +183,7 @@ public class DayDismissalPredicateTest {
         ));
 
         // Thursday
-        Day thursday= new Day(queryTime);
+        Day thursday = new Day(queryTime);
         assertTrue(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
                 new StudentBuilder().withThursdayDismissal(subjectTime).build()
         ));
@@ -219,7 +219,7 @@ public class DayDismissalPredicateTest {
         ));
 
         // Thursday
-        Day thursday= new Day(queryTime);
+        Day thursday = new Day(queryTime);
         assertTrue(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
                 new StudentBuilder().withThursdayDismissal(subjectTime).build()
         ));
@@ -255,7 +255,7 @@ public class DayDismissalPredicateTest {
         ));
 
         // Thursday
-        Day thursday= new Day(queryTime);
+        Day thursday = new Day(queryTime);
         assertFalse(new ThursdayDismissalPredicate(thursday.dismissalTime).test(
                 new StudentBuilder().withThursdayDismissal(subjectTime).build()
         ));

--- a/src/test/java/seedu/address/model/student/EmailContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/EmailContainsKeywordPredicateTest.java
@@ -1,0 +1,56 @@
+package seedu.address.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.StudentBuilder;
+
+class EmailContainsKeywordPredicateTest {
+
+    @Test
+    void equals() {
+        String firstKeyword = "meow";
+        String secondKeyword = "woof";
+
+        EmailContainsKeywordPredicate firstPredicate = new EmailContainsKeywordPredicate(firstKeyword);
+        EmailContainsKeywordPredicate secondPredicate = new EmailContainsKeywordPredicate(secondKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordPredicate firstPredicateCopy = new EmailContainsKeywordPredicate(firstKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keyword -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    void test_emailContainsKeyword_returnsTrue() {
+        EmailContainsKeywordPredicate predicate = new EmailContainsKeywordPredicate("meow");
+
+        // domain contains
+        assertTrue(predicate.test(new StudentBuilder().withEmail("JohnDoe@meow.edu").build()));
+
+        // local part contains
+        assertTrue(predicate.test(new StudentBuilder().withEmail("meow@lolmail.com").build()));
+
+        // substring matches
+        assertTrue(predicate.test(new StudentBuilder().withEmail("usermeows@woof.com").build()));
+    }
+
+    @Test
+    void test_emailDoesNotContainKeyword_returnsFalse() {
+        EmailContainsKeywordPredicate predicate = new EmailContainsKeywordPredicate("0");
+        assertFalse(predicate.test(new StudentBuilder().withEmail("JohnDoe@meow.edu").build()));
+    }
+}


### PR DESCRIPTION
**What's new**
* Find by dismissal time (d1 to d5)
   * Students with dismissal time _equal OR before_ the query time will be matched
   * E.g. `d1/1500` will match `1500` and `1200`, but not `1501` on Monday
* Empty query in `find` command is no longer valid - Error message will be shown
* All test cases implemented
<br>

**Usage examples**
* `find n/Alex d2/1600`
* `find d3/1400`
* `find d1/1000 d3/1000 d5/1000`
<br>

**Other**
* Test cases for Find by Academic Year - `AcademicYearMatchesPredicateTest`
* Test cases for Find by Email - `EmailContainsPredicateTest`