### PR TITLE
Add training schedule container in Student

### DIFF
--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -2,10 +2,12 @@ package seedu.address.model.student;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 import seedu.address.model.student.time.Day;
 import seedu.address.model.tag.Tag;
@@ -32,6 +34,9 @@ public class Student {
 
     private final Set<Tag> tags = new HashSet<>();
 
+    //Collection of scheduled training dates tagged to the particular student
+    private final TreeSet<LocalDateTime> trainingSchedules = new TreeSet<>();
+
     /**
      * Every field must be present and not null.
      */
@@ -50,6 +55,46 @@ public class Student {
         this.thursdayDismissal = thursdayDismissal;
         this.fridayDismissal = fridayDismissal;
         this.tags.addAll(tags);
+    }
+
+    /**
+     * Adds a training session to the student's schedule.
+     * Training sessions are automatically sorted by their respective date and times.
+     *
+     * @param trainingDateTime LocalDateTime corresponding to the training's date and start time.
+     * Duplicates are not allowed and will not be added.
+     */
+    public void addTraining(LocalDateTime trainingDateTime) {
+        trainingSchedules.add(trainingDateTime);
+    }
+
+    /**
+     * Checks if student has a training scheduled at the specified date and start time.
+     *
+     * @param trainingDateTime LocalDateTime corresponding to the training's date and start time.
+     * Specified training must exist in the student's training schedule.
+     * @return true If a training has been scheduled at the specified date and time.
+     */
+    public boolean containsTraining(LocalDateTime trainingDateTime) {
+        return trainingSchedules.contains(trainingDateTime);
+    }
+
+    /**
+     * Removes a scheduled training from the student's training schedule.
+     *
+     * @param trainingDateTime LocalDateTime corresponding to the training's date and start time.
+     */
+    public void removeTraining(LocalDateTime trainingDateTime) {
+        if (containsTraining(trainingDateTime)) {
+            trainingSchedules.remove(trainingDateTime);
+        }
+    }
+
+    /**
+     * Clears all trainings scheduled for the student.
+     */
+    public void clearAllTraining() {
+        trainingSchedules.clear();
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -91,9 +91,9 @@ public class Student {
     }
 
     /**
-     * Clears all trainings scheduled for the student.
+     * Removes all trainings scheduled for the student.
      */
-    public void clearAllTraining() {
+    public void removeAllTraining() {
         trainingSchedules.clear();
     }
 


### PR DESCRIPTION
Training Schedule Container implemented in Student class using a TreeSet 
- TreeSet<LocalDateTime> trainingSchedules
- Allows easy addition/removal of training dates and times from the set

Why LocalDateTime?
1. Easy parsing of both dates and times
2. Each training should have a date and a start-time
3. Naturally comparable (so allows for easy sorting within treeset)
4. Helper methods to compare already available

Reasons for using TreeSet:

1.  Provides methods for majority of our required CRUD operations (add, remove, first, contains, custom comparators, ceiling, clear, descending) - for reference can refer here: https://www.geeksforgeeks.org/treeset-in-java-with-examples/
2. Automatic sorting of added LocalDateTime objects as they are comparable, hence no manual sorting needed, just add and dates will be sorted from most recent onwards
3. No Duplicates allowed in a Set (we don't want duplicated training dates) and there can only be one maximal training for each student on the same day

**Methods Implemented (for now)

- addTraining(LocalDateTime trainingDateTime)
- containsTraining(LocalDateTime trainingDateTime)
- removeTraining(LocalDateTime trainingDateTime)
- clearAllTraining()**

Take note all take in a LocalDateTime object, and the TreeSet should therefore also store only LocalDateTime objects, cannot mix with LocalDate or LocalTime only.

The Date should correspond to the date of the training and the time, the **START**-time of the training. Formatting of the LocalDateTime object should also be observed as DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm")