### PR TITLE
[Closes #110] Modify training command to only allow present and future date and time

### DIFF
--- a/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
@@ -21,6 +21,7 @@ public class TrainingCommand extends Command {
     public static final String MESSAGE_SUCCESS_TRAINING = "New Training Session created at: %1$s";
     public static final String MESSAGE_DUPLICATE_TRAINING = "There "
             + "already exists a Training Session at this Date and Time";
+    public static final String MESSAGE_PAST_TRAINING = "Trainings can only be scheduled for the future!";
 
     private final Training toAdd;
 
@@ -40,11 +41,15 @@ public class TrainingCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasTraining(toAdd)) {
+        if (getTraining().getDateTime().isBefore(LocalDateTime.now())) {
+            throw new CommandException(MESSAGE_PAST_TRAINING);
+        }
+
+        if (model.hasTraining(getTraining())) {
             throw new CommandException(MESSAGE_DUPLICATE_TRAINING);
         }
 
-        model.addTraining(toAdd);
+        model.addTraining(getTraining());
         return new CommandResult(String.format(MESSAGE_SUCCESS_TRAINING, toAdd));
     }
 
@@ -52,6 +57,6 @@ public class TrainingCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TrainingCommand // instanceof handles nulls
-                && toAdd.equals(((TrainingCommand) other).toAdd));
+                && getTraining().equals(((TrainingCommand) other).getTraining()));
     }
 }

--- a/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
@@ -21,7 +21,7 @@ public class TrainingCommand extends Command {
     public static final String MESSAGE_SUCCESS_TRAINING = "New Training Session created at: %1$s";
     public static final String MESSAGE_DUPLICATE_TRAINING = "There "
             + "already exists a Training Session at this Date and Time";
-    public static final String MESSAGE_PAST_TRAINING = "Trainings can only be scheduled for the future!";
+    public static final String MESSAGE_PAST_TRAINING = "Trainings cannot be scheduled for dates that are past!";
 
     private final Training toAdd;
 

--- a/src/test/java/seedu/canoe/logic/commands/TrainingCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/TrainingCommandTest.java
@@ -10,6 +10,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.canoe.logic.commands.exceptions.CommandException;
 import seedu.canoe.model.Model;
 import seedu.canoe.model.ModelManager;
 
@@ -27,6 +28,16 @@ public class TrainingCommandTest {
         String expectedCommandResult = new TrainingCommand(validDateTime).execute(expectedModel).getFeedbackToUser();
         assertCommandSuccess(new TrainingCommand(VALID_TRAINING.getDateTime()),
                 model, expectedCommandResult, expectedModel);
+    }
+
+    //tests with a invalid Training object set in the past
+    @Test
+    public void execute_pastTraining_throwsCommandException() throws Exception {
+        LocalDateTime pastDateTime = LocalDateTime.parse("2020-08-26 1800",
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+        TrainingCommand pastTrainingCommand = new TrainingCommand(pastDateTime);
+        assertThrows(CommandException.class, TrainingCommand.MESSAGE_PAST_TRAINING, () ->
+            pastTrainingCommand.execute(expectedModel));
     }
 
     //tests with a invalid Training object with invalid month.


### PR DESCRIPTION
- Added a check to prevent users from entering date times in the past when they call the training command