### PR TITLE
Refactor commontime command to check for no student matches

### DIFF
--- a/src/main/java/seedu/canoe/commons/core/Messages.java
+++ b/src/main/java/seedu/canoe/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "One of the Student Ids provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_STUDENTS_NOT_FOUND = "Search result matches no students!";
     public static final String MESSAGE_INVALID_TRAINING_DISPLAYED_INDEX = "The Training index provided is invalid";
     public static final String MESSAGE_INVALID_DATE_TIME = "The date and time\n provided is not valid";
     public static final String MESSAGE_DUPLICATE_STUDENTS_IN_TRAINING = "One "

--- a/src/main/java/seedu/canoe/logic/commands/CommonTimeCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/CommonTimeCommand.java
@@ -1,13 +1,17 @@
 package seedu.canoe.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.canoe.commons.core.Messages.MESSAGE_STUDENTS_NOT_FOUND;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.canoe.commons.core.LogsCenter;
 import seedu.canoe.model.Model;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.CommonTimeFinder;
+import seedu.canoe.model.student.exceptions.StudentNotFoundException;
 
 /**
  * Finds the latest dismissal time of all the students stated in the keywords.
@@ -15,7 +19,9 @@ import seedu.canoe.model.student.CommonTimeFinder;
  */
 public class CommonTimeCommand extends Command {
 
-    public static final String COMMAND_WORD = "commonTime";
+    public static final Logger logger = LogsCenter.getLogger(CommonTimeCommand.class);
+
+    public static final String COMMAND_WORD = "common-time";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds a common time amongst all selected students "
@@ -33,8 +39,15 @@ public class CommonTimeCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
+        logger.info("=============================[ Executing CommonTimeCommand ]===========================");
         requireNonNull(model);
         model.updateFilteredStudentList(predicates);
+
+        if (model.getFilteredStudentList().isEmpty()) {
+            logger.warning("Keywords match zero students.");
+            return new CommandResult(MESSAGE_STUDENTS_NOT_FOUND);
+        }
+
         commonDismissalTimes = new CommonTimeFinder(model.getFilteredStudentList()).getCommonDismissalTimes();
         return new CommandResult(commonDismissalTimesToString(commonDismissalTimes));
     }

--- a/src/main/java/seedu/canoe/logic/commands/CommonTimeCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/CommonTimeCommand.java
@@ -11,7 +11,6 @@ import seedu.canoe.commons.core.LogsCenter;
 import seedu.canoe.model.Model;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.CommonTimeFinder;
-import seedu.canoe.model.student.exceptions.StudentNotFoundException;
 
 /**
  * Finds the latest dismissal time of all the students stated in the keywords.

--- a/src/main/java/seedu/canoe/logic/parser/CommonTimeCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/CommonTimeCommandParser.java
@@ -6,7 +6,9 @@ import static seedu.canoe.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.canoe.commons.core.LogsCenter;
 import seedu.canoe.logic.commands.CommonTimeCommand;
 import seedu.canoe.logic.parser.exceptions.ParseException;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
@@ -18,11 +20,14 @@ import seedu.canoe.model.student.NameContainsKeywordsPredicate;
  */
 public class CommonTimeCommandParser implements Parser<CommonTimeCommand> {
 
+    private static final Logger logger = LogsCenter.getLogger(CommonTimeCommand.class);
+
     /**
      * Parses the given {@code String} of arguments in the context of the CommonTimeCommand
      * and returns a CommonTimeCommand object for execution.
      */
     public CommonTimeCommand parse(String args) throws ParseException {
+        logger.info("=============================[ Parsing CommonTimeCommand ]===========================");
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ACADEMIC_YEAR);
@@ -33,6 +38,7 @@ public class CommonTimeCommandParser implements Parser<CommonTimeCommand> {
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String text = argMultimap.getValue(PREFIX_NAME).get();
             if (text.equals("")) {
+                logger.warning("No keyword found after name prefix!" + text);
                 checkEmptyString = true;
             } else {
                 predicates.add(new NameContainsKeywordsPredicate(getKeywordsFromString(text)));
@@ -42,12 +48,14 @@ public class CommonTimeCommandParser implements Parser<CommonTimeCommand> {
         if (argMultimap.getValue(PREFIX_ACADEMIC_YEAR).isPresent()) {
             String academicYearValue = argMultimap.getValue(PREFIX_ACADEMIC_YEAR).get();
             if (!academicYearValue.equals("")) {
+                logger.warning("No keyword found after academic year prefix!");
                 checkEmptyString = false;
                 predicates.add(new AcademicYearMatchesPredicate(academicYearValue));
             }
         }
 
         if (predicates.isEmpty() || checkEmptyString) {
+            logger.warning("No prefixes found in the command input!" + args);
             throw new ParseException(CommonTimeCommand.MESSAGE_NO_QUERY);
         }
 

--- a/src/test/java/seedu/canoe/logic/commands/CommonTimeCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/CommonTimeCommandTest.java
@@ -32,8 +32,7 @@ class CommonTimeCommandTest {
 
     @Test
     public void execute_zeroKeywords_defaultDismissalTimes() {
-        String expectedMessage = "Monday: 15:00\n"
-                + "Tuesday: 15:00\n" + "Wednesday: 15:00\n" + "Thursday: 15:00\n" + "Friday: 15:00";
+        String expectedMessage = "Search result matches no students!";
         NameContainsKeywordsPredicate namePredicate = preparePredicate(" ");
         AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate(" ");
         AnyMatchPredicateList predicateList = new AnyMatchPredicateList(


### PR DESCRIPTION
- Added a guard clause in the commontimecommand::execute() method that returns a feedback telling the user that the search keywords match no students.
- Added a new message in the Messages class to inform users that the keywords match no students.
- Added loggers for commontimecommandparser and commontimecommand
- Refactor commontimecommand word to common-time from commonTime
