### PR TITLE
Update list and training commands to un-filter training panel

### DIFF
--- a/src/main/java/seedu/canoe/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/ListCommand.java
@@ -12,12 +12,14 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all students";
+    public static final String MESSAGE_SUCCESS = "Listed all students and trainings.";
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        //Make sure all students and trainings are displayed on student and training panel
+        model.updateFilteredTrainingList(Model.PREDICATE_SHOW_ALL_TRAININGS);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/TrainingCommand.java
@@ -40,6 +40,8 @@ public class TrainingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        //Make sure all trainings are displayed on training panel
+        model.updateFilteredTrainingList(Model.PREDICATE_SHOW_ALL_TRAININGS);
 
         if (getTraining().getDateTime().isBefore(LocalDateTime.now())) {
             throw new CommandException(MESSAGE_PAST_TRAINING);


### PR DESCRIPTION
- Currently, the training panel cannot be defaulted to show all trainings after it has been filtered (e.g. by the find-training command)
- Hence, added an additional step to both the list and training commands to un-filter the training panel to show all trainings once the commands have successfully executed
