### PR TITLE
Update student GUI to support both past and present training display with colour coding

### DIFF
--- a/src/main/java/seedu/canoe/model/student/Attendance.java
+++ b/src/main/java/seedu/canoe/model/student/Attendance.java
@@ -3,6 +3,7 @@ package seedu.canoe.model.student;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+
 /**
  * Represents an attendance for a training session.
  */

--- a/src/main/java/seedu/canoe/ui/StudentCard.java
+++ b/src/main/java/seedu/canoe/ui/StudentCard.java
@@ -71,9 +71,9 @@ public class StudentCard extends UiPart<Region> {
     public StudentCard(Student student, int displayedIndex) {
         super(FXML);
         this.student = student;
-        Background markedAttendance = new Background(new BackgroundFill(Color.RED,
+        Background unmarkedAttendance = new Background(new BackgroundFill(Color.RED,
                 null, null));
-        Background unmarkedAttendance = new Background(new BackgroundFill(Color.GREEN,
+        Background markedAttendance = new Background(new BackgroundFill(Color.GREEN,
                 null, null));
         id.setText(displayedIndex + ". ");
         studentId.setText("ID: " + student.getId());
@@ -109,8 +109,8 @@ public class StudentCard extends UiPart<Region> {
                         .isBefore(LocalDateTime.now())).collect(Collectors.toList())) {
             Label pastAttendanceLabel = new Label(attendance.toString());
             pastAttendanceLabel.backgroundProperty().bind(
-                    new When(isMarked(attendance.getAttendance())).then(unmarkedAttendance)
-                            .otherwise(markedAttendance));
+                    new When(isMarked(attendance.getAttendance())).then(markedAttendance)
+                            .otherwise(unmarkedAttendance));
             pastTrainingAttendances.getChildren().add(pastAttendanceLabel);
         }
         upcomingTrainingTag.setText("Upcoming Trainings Scheduled : ");
@@ -120,8 +120,8 @@ public class StudentCard extends UiPart<Region> {
                         .isAfter(LocalDateTime.now())).collect(Collectors.toList())) {
             Label upcomingAttendanceLabel = new Label(attendance.toString());
             upcomingAttendanceLabel.backgroundProperty().bind(
-                    new When(isMarked(attendance.getAttendance())).then(unmarkedAttendance)
-                            .otherwise(markedAttendance));
+                    new When(isMarked(attendance.getAttendance())).then(markedAttendance)
+                            .otherwise(unmarkedAttendance));
             upcomingTrainingAttendances.getChildren().add(upcomingAttendanceLabel);
         }
     }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -351,12 +351,26 @@
     -fx-font-size: 11;
 }
 
-#trainingAttendances {
+#pastTrainingAttendances {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#trainingAttendances .label {
+#upcomingTrainingAttendances {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#pastTrainingAttendances .label {
+    -fx-text-fill: white;
+    -fx-background-color: #800000;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+#upcomingTrainingAttendances .label {
     -fx-text-fill: white;
     -fx-background-color: #800000;
     -fx-padding: 1 3 1 3;

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -35,8 +35,10 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="academicYear" styleClass="cell_small_label" text="\$academicYear" />
       <Separator fx:id="trainingSeparator" />
-      <Label fx:id="trainingTag" styleClass="cell_small_label" text="\$trainingTag" />
-      <FlowPane fx:id="trainingAttendances" />
+      <Label fx:id="pastTrainingTag" styleClass="cell_small_label" text="\$pastTrainingTag" />
+      <FlowPane fx:id="pastTrainingAttendances" />
+      <Label fx:id="upcomingTrainingTag" styleClass="cell_small_label" text="\$upcomingTrainingTag" />
+      <FlowPane fx:id="upcomingTrainingAttendances" />
       <Separator fx:id="dismissalTimeSeparator" />
       <Label fx:id="dismissalTime" styleClass="cell_small_label" text="\$dismissalTime" />
       <FlowPane fx:id="dismissalTimes" />


### PR DESCRIPTION
- Student Panel now displays both past and present trainings, separated
- Training attendance label is green when attendance is marked, red otherwise
- Training will be classified by past, if its start-time **+ 3 hours** is after the current time (hence, we have a buffer of 3 hours put into place as trainings are on average 3 hours in duration, and we want the training to still be in the upcoming section when it is ongoing)
- Utilised .bind() in order to dynamically set the background property of the Labels for the attendances