### PR TITLE
Fix Ui and dismisal time bugs and update User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,7 +110,9 @@ Format: `edit STUDENT_INDEX [n/NAME] [p/PHONE] [e/EMAIL] [ay/ACADEMIC_YEAR] [d1/
 * You can remove all of the student’s tags by typing `t/` without specifying any tags after it.
 * Take note that editing the details of a student will also propagate the changes on the training panel.
 * Be careful when editing dismissal times, as this might automatically remove students from scheduled trainings if
- the updated dismissal time on the same day of the week is now later than the start time of any of the student's scheduled trainings.
+ the updated dismissal time on the same day of the week is now later than the start time of any of the student's upcoming scheduled trainings. Past trainings will not be affected.
+ 
+> All trainings are given a buffer of 3 hours from their start times before they are classified as "past training" (i.e. A training scheduled on 29 October 2021 1500 will be classified as a "past training" on 29 October 2021, 1800).
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com d1/1600` Edits the phone number and email address of the 1st student in the displayed student list to be `91234567` and `johndoe@example.com` respectively. This also changes his Monday's dismissal time to 1600.
@@ -122,9 +124,9 @@ Deletes the specified student from the student list.
 
 Format: `delete STUDENT_INDEX`
 - Deletes the student at the specified `STUDENT_INDEX`.
-- The student index refers to the index number shown in the displayed student list.
+- The student index refers to the index number shown in the displayed student list. (This is different from the unique ID of each student.)
 - The index must be an unsigned integer 1, 2, 3, …
-- This will remove the student from all of his/her scheduled training sessions.
+- This will remove the student from all of his/her scheduled training sessions (both past and present).
 
 Examples:
 - `delete 2` deletes the 2nd student in the displayed student list.
@@ -173,8 +175,7 @@ Examples:
 - `find e/alexyeoh@example.com p/456` returns an empty list, if such an email **AND** contact number is not present in the student list
 
 ### Common Time : `commonTime`
-Returns the latest dismissal times on all days for all of the students in the specified subgroup. This would be the earliest
-time to schedule a training for all students in the sub group.
+Returns the latest dismissal times on all days for all of the students in the specified subgroup. This would be the earliest time to schedule a training for all students in the sub group.
 
 Format: `commonTime [n/KEYWORDS] [ay/ACADEMIC_YEAR]`
 
@@ -215,7 +216,8 @@ Deletes an existing training from the training list.
 Format: `delete-training TRAINING_INDEX`
 
 * Deletes the training at the specified `TRAINING_INDEX`.
-* Training index refers to the index of the training in the displayed training list.
+* Training index refers to the index of the training in the unfiltered training list.
+* Take note that even if training list is filtered, the ids of the entire unfiltered training list is utilised, hence, always do a `list` command before deleting the correct training. 
 * The index must be an unsigned integer 1, 2, 3, …
 * All students inside of the training to be deleted will have the training removed from their training schedules.
 
@@ -227,7 +229,8 @@ Adds students to a training.
 
 Format: `ts-add TRAINING_INDEX id/STUDENT_ID...`
 
-* Training index refers to the index of the training in the displayed training list.
+* Training index refers to the index of the training in the unfiltered training list.
+* Take note that even if training list is filtered, the ids of the entire unfiltered training list is utilised, hence, always do a `list` command before adding the student. 
 * Multiple students can be added with the same command by inputing multiple student indexes separated with a comma.
 * Only one training index can be specified at a time.
 * Each student can only be added to a **SINGLE** training on the same date regardless of time.
@@ -243,7 +246,9 @@ Adds all available students to a training.
 
 Format: `ts-addall TRAINING_INDEX`
 
-* Training index refers to the index of the training in the displayed training list.
+* Training index refers to the index of the training in the **displayed** training list.
+* Take note that even if training list is filtered, the ids of the entire unfiltered training list is utilised, hence, always do a `list` command before adding the students. 
+* Take note that this command only looks at students and trainings based on the displayed training list, and not the entire unfiltered training list.
 * All students displayed in the student list will be added to the training if they can be added.
 * A student can be added to the training if and only if:
    * They are available for the training's date time based on their dismissal times
@@ -261,7 +266,8 @@ Deletes students from a training.
 
 Format: `ts-delete TRAINING_INDEX id/STUDENT_ID...`
 
-* Training index refers to the index of the training in the displayed training list.
+* Training index refers to the index of the training in the unfiltered training list.
+* Take note that even if training list is filtered, the ids of the entire unfiltered training list is utilised, hence, always do a `list` command before deleting the student from the training. 
 * Multiple students can be deleted with the same command by listing multiple student Ids separated with a comma.
 * Only one training index can be specified at a time.
 

--- a/src/main/java/seedu/canoe/model/student/Student.java
+++ b/src/main/java/seedu/canoe/model/student/Student.java
@@ -378,7 +378,8 @@ public class Student {
 
         boolean isAvailable = true;
         for (Attendance attendance: trainingAttendances) {
-            if (!isAvailableAtDateTime(attendance.getTrainingTime())) {
+            if (attendance.getTrainingTime().plusHours(3).isAfter(LocalDateTime.now())
+                    && !isAvailableAtDateTime(attendance.getTrainingTime())) {
                 isAvailable = false;
             }
         }

--- a/src/main/java/seedu/canoe/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/canoe/model/util/SampleDataUtil.java
@@ -32,7 +32,7 @@ public class SampleDataUtil {
     public static Training[] getPastSampleTraining() {
         LocalDateTime pastDateTime = LocalDateTime.parse("2020-08-26 1500",
                 DateTimeFormatter.ofPattern("yyyy-MM-dd " + "HHmm"));
-        LocalDateTime secondPastDateTime = LocalDateTime.parse("2020-09-15 1400",
+        LocalDateTime secondPastDateTime = LocalDateTime.parse("2020-09-15 1500",
                 DateTimeFormatter.ofPattern("yyyy-MM-dd " + "HHmm"));
         Training firstTraining = new Training(pastDateTime);
         Training secondTraining = new Training(secondPastDateTime);
@@ -44,7 +44,7 @@ public class SampleDataUtil {
     }
 
     public static Training[] getFutureSampleTraining() {
-        LocalDateTime nearFutureDateTime = LocalDateTime.parse("2021-01-26 1400",
+        LocalDateTime nearFutureDateTime = LocalDateTime.parse("2021-01-26 1500",
                 DateTimeFormatter.ofPattern("yyyy-MM-dd " + "HHmm"));
         LocalDateTime secondNearFutureDateTime = LocalDateTime.parse("2021-02-12 1500",
                 DateTimeFormatter.ofPattern("yyyy-MM-dd " + "HHmm"));

--- a/src/main/java/seedu/canoe/model/util/StudentTrainingSessionUtil.java
+++ b/src/main/java/seedu/canoe/model/util/StudentTrainingSessionUtil.java
@@ -1,5 +1,6 @@
 package seedu.canoe.model.util;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,7 +16,8 @@ public class StudentTrainingSessionUtil {
         Set<Attendance> trainingSchedules, Student student) {
         List<Attendance> conflicts = trainingSchedules
                 .stream()
-                .filter(attend -> !student.isAvailableAtDateTime(attend.getTrainingTime()))
+                .filter(attend -> attend.getTrainingTime().plusHours(3).isAfter(LocalDateTime.now())
+                        && !student.isAvailableAtDateTime(attend.getTrainingTime()))
                 .collect(Collectors.toList());
         return conflicts;
     }

--- a/src/main/java/seedu/canoe/ui/TrainingCard.java
+++ b/src/main/java/seedu/canoe/ui/TrainingCard.java
@@ -8,9 +8,9 @@ import java.util.Locale;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.canoe.model.training.Training;
 
 /**
@@ -31,13 +31,13 @@ public class TrainingCard extends UiPart<Region> {
     public final Training training;
 
     @FXML
-    private HBox cardPane2;
+    private HBox trainingCardPane;
     @FXML
     private Label id;
     @FXML
     private Label name;
     @FXML
-    private FlowPane students;
+    private VBox students;
 
     /**
      * Creates a {@code StudentCode} with the given {@code Student} and index to display.

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -116,6 +116,11 @@
     -fx-border-width: 1;
 }
 
+.list-cell:filled:selected #trainingCardPane {
+    -fx-border-color: #3e7b91;
+    -fx-border-width: 1;
+}
+
 .list-cell .label {
     -fx-text-fill: white;
 }
@@ -309,7 +314,21 @@
 
 #cardPane {
     -fx-background-color: transparent;
+    -fx-border-width: 1;
+    -fx-border-color: #383838 #383838 #ffffff #383838;
+    -fx-border-insets: 0;
+}
+
+#trainingCardPane {
+    -fx-background-color: transparent;
     -fx-border-width: 0;
+    -fx-padding: 8 1 8 1;
+    -fx-background-color: transparent #383838 transparent #383838;
+    -fx-background-insets: 0;
+    -fx-border-color: #383838 #383838 #ffffff #383838;
+    -fx-border-insets: 0;
+    -fx-border-width: 1;
+
 }
 
 #commandTypeLabel {
@@ -384,6 +403,7 @@
     -fx-vgap: 3;
 }
 
+
 #dismissalTimes .label {
     -fx-text-fill: white;
     -fx-background-color: #808000;
@@ -392,4 +412,10 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#students {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -8,7 +8,8 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8"
+         xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 <?import javafx.stage.Stage?>
 
 <fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="CanoE-COACH" type="javafx.stage.Stage"
-         xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+         xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/canoe_coach.png" />
   </icons>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.control.Separator?>
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/StudentListPanel.fxml
+++ b/src/main/resources/view/StudentListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="studentListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/TrainingListCard.fxml
+++ b/src/main/resources/view/TrainingListCard.fxml
@@ -10,7 +10,8 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.control.Separator?>
-<HBox id="cardPane2" fx:id="cardPane2" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="trainingCardPane" fx:id="trainingCardPane" xmlns="http://javafx.com/javafx/8"
+      xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -29,7 +30,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <Separator fx:id="trainingCardSeparator" />
-      <FlowPane fx:id="students" />
+      <VBox fx:id="students" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
- Fixed bug where editing student's dismissal times will change past trainings (this should not be the case)
- Fixed Ui bug that causes students in trainings to wrap around each other (changed Flowpane used to VBox)
- Added separators for clearer structure
- Edited sample data for consistency of training data (all sample data training timings are fixed at 1500, as default sample dismissal time is also 1500 hours)
- Edited User Guide