### PR TITLE
Prevent rounding of user input DateTimes

### DIFF
--- a/src/main/java/seedu/canoe/commons/core/Messages.java
+++ b/src/main/java/seedu/canoe/commons/core/Messages.java
@@ -5,15 +5,15 @@ package seedu.canoe.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "One of the Student Ids provided is invalid";
+    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "One of the Student Ids provided is invalid!";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_TRAININGS_LISTED_OVERVIEW = "%1$d trainings listed!";
     public static final String MESSAGE_STUDENTS_NOT_FOUND = "Search result matches no students!";
     public static final String MESSAGE_TRAININGS_NOT_FOUND = "Search result matches no trainings!";
-    public static final String MESSAGE_INVALID_TRAINING_DISPLAYED_INDEX = "The Training index provided is invalid";
-    public static final String MESSAGE_INVALID_DATE_TIME = "The date and time\n provided is not valid";
+    public static final String MESSAGE_INVALID_TRAINING_DISPLAYED_INDEX = "The Training index provided is invalid!";
+    public static final String MESSAGE_INVALID_DATE_TIME = "The date and time provided is not valid!";
     public static final String MESSAGE_DUPLICATE_STUDENTS_IN_TRAINING = "One "
             + "of the Students provided is already in the Training Session!";
 }

--- a/src/main/java/seedu/canoe/logic/commands/AddStudentToTrainingCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/AddStudentToTrainingCommand.java
@@ -67,11 +67,11 @@ public class AddStudentToTrainingCommand extends Command {
         LOGGER.info("==========================[ Executing AddStudentToTrainingCommand ]==========================");
 
         requireNonNull(model);
+        assert (model != null);
 
         List<Training> lastShownList = model.getFilteredTrainingList();
         List<Student> studentList = model.getFilteredStudentList();
 
-        //Throws a CommandException if there are no Students in studentList
         if (studentList.isEmpty()) {
             throw new CommandException(MESSAGE_NO_STUDENTS);
         }

--- a/src/main/java/seedu/canoe/logic/parser/FindStudentTrainingCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/FindStudentTrainingCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.canoe.logic.parser.CliSyntax.PREFIX_ID;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -68,7 +69,7 @@ public class FindStudentTrainingCommandParser implements Parser<FindStudentTrain
             }
             try {
                 LocalDateTime dateTime = LocalDateTime.parse(dateTimeValue,
-                        DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+                        DateTimeFormatter.ofPattern("uuuu-MM-dd HHmm").withResolverStyle(ResolverStyle.STRICT));
                 studentPredicate = new DateTimeMatchesPredicate(dateTime);
                 trainingPredicate = new TrainingMatchesDateTimePredicate(dateTime);
             } catch (DateTimeParseException e) {
@@ -81,7 +82,7 @@ public class FindStudentTrainingCommandParser implements Parser<FindStudentTrain
             String dateTimeValue = argMultimap.getValue(PREFIX_DATETIME).get();
             try {
                 LocalDateTime dateTime = LocalDateTime.parse(dateTimeValue,
-                        DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+                        DateTimeFormatter.ofPattern("uuuu-MM-dd HHmm").withResolverStyle(ResolverStyle.STRICT));
                 studentPredicate = new IdMatchesPredicate(idValue);
                 trainingPredicate = new TrainingMatchesDateTimePredicate(dateTime);
             } catch (DateTimeParseException e) {

--- a/src/main/java/seedu/canoe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/canoe/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -142,7 +143,8 @@ public class ParserUtil {
     public static Training parseTraining(String training) throws ParseException {
         requireNonNull(training);
         String trimmedTraining = training.trim();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HHmm")
+                .withResolverStyle(ResolverStyle.STRICT);
         try {
             LocalDateTime dateTime = LocalDateTime.parse(trimmedTraining, formatter);
             return new Training(dateTime);


### PR DESCRIPTION
Used Strict ResolverStyle to prevent rounding of user input DateTimes, in both the addition of trainings and the finding of trainings.

Standardised "!" at the end of error messages.