### PR TITLE
Update FindCommand & Parser and Id Stuff

### DIFF
--- a/src/main/java/seedu/canoe/logic/parser/CommonTimeCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/CommonTimeCommandParser.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 import seedu.canoe.commons.core.LogsCenter;
 import seedu.canoe.logic.commands.CommonTimeCommand;
 import seedu.canoe.logic.parser.exceptions.ParseException;
+import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
@@ -50,7 +51,8 @@ public class CommonTimeCommandParser implements Parser<CommonTimeCommand> {
             if (!academicYearValue.equals("")) {
                 LOGGER.warning("No keyword found after academic year prefix!");
                 checkEmptyString = false;
-                predicates.add(new AcademicYearMatchesPredicate(academicYearValue));
+                predicates.add(new AcademicYearMatchesPredicate(
+                        new AcademicYear(academicYearValue)));
             }
         }
 

--- a/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import seedu.canoe.logic.commands.FindCommand;
 import seedu.canoe.logic.parser.exceptions.ParseException;
+import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
 import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.EmailContainsKeywordPredicate;
@@ -80,7 +81,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             String academicYearValue = argMultimap.getValue(PREFIX_ACADEMIC_YEAR).get();
             if (!academicYearValue.isEmpty()) {
                 checkEmptyString = false;
-                predicates.add(new AcademicYearMatchesPredicate(academicYearValue));
+                AcademicYear year = ParserUtil.parseAcademicYear(academicYearValue);
+                predicates.add(new AcademicYearMatchesPredicate(year));
             }
         }
 

--- a/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
@@ -23,6 +23,7 @@ import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.EmailContainsKeywordPredicate;
 import seedu.canoe.model.student.IdMatchesPredicate;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
+import seedu.canoe.model.student.Phone;
 import seedu.canoe.model.student.PhoneMatchesPredicate;
 import seedu.canoe.model.student.time.Day;
 import seedu.canoe.model.student.time.FridayDismissalPredicate;
@@ -40,7 +41,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      */
-    public FindCommand parse(String args) throws ParseException {
+    public FindCommand parse(String args) throws ParseException, IllegalArgumentException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ACADEMIC_YEAR,
@@ -51,7 +52,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         AllMatchPredicateList predicates = new AllMatchPredicateList();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String text = argMultimap.getValue(PREFIX_NAME).get();
-            if (text.equals("")) {
+            if (text.isEmpty()) {
                 checkEmptyString = true;
             } else {
                 predicates.add(new NameContainsKeywordsPredicate(getKeywordsFromString(text)));
@@ -60,15 +61,16 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             String phoneValue = argMultimap.getValue(PREFIX_PHONE).get();
-            if (!phoneValue.equals("")) {
+            if (!phoneValue.isEmpty()) {
                 checkEmptyString = false;
-                predicates.add(new PhoneMatchesPredicate(phoneValue));
+                Phone phone = ParserUtil.parsePhone(phoneValue);
+                predicates.add(new PhoneMatchesPredicate(phone));
             }
         }
 
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             String keyword = argMultimap.getValue(PREFIX_EMAIL).get();
-            if (!keyword.equals("")) {
+            if (!keyword.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new EmailContainsKeywordPredicate(keyword));
             }
@@ -76,7 +78,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_ACADEMIC_YEAR).isPresent()) {
             String academicYearValue = argMultimap.getValue(PREFIX_ACADEMIC_YEAR).get();
-            if (!academicYearValue.equals("")) {
+            if (!academicYearValue.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new AcademicYearMatchesPredicate(academicYearValue));
             }
@@ -84,7 +86,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_MONDAY_DISMISSAL).isPresent()) {
             String timeString = argMultimap.getValue(PREFIX_MONDAY_DISMISSAL).get();
-            if (!timeString.equals("")) {
+            if (!timeString.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new MondayDismissalPredicate(getTimeFromString(timeString)));
             }
@@ -92,7 +94,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_TUESDAY_DISMISSAL).isPresent()) {
             String timeString = argMultimap.getValue(PREFIX_TUESDAY_DISMISSAL).get();
-            if (!timeString.equals("")) {
+            if (!timeString.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new TuesdayDismissalPredicate(getTimeFromString(timeString)));
             }
@@ -100,7 +102,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_WEDNESDAY_DISMISSAL).isPresent()) {
             String timeString = argMultimap.getValue(PREFIX_WEDNESDAY_DISMISSAL).get();
-            if (!timeString.equals("")) {
+            if (!timeString.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new WednesdayDismissalPredicate(getTimeFromString(timeString)));
             }
@@ -108,7 +110,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_THURSDAY_DISMISSAL).isPresent()) {
             String timeString = argMultimap.getValue(PREFIX_THURSDAY_DISMISSAL).get();
-            if (!timeString.equals("")) {
+            if (!timeString.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new ThursdayDismissalPredicate(getTimeFromString(timeString)));
             }
@@ -116,7 +118,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_FRIDAY_DISMISSAL).isPresent()) {
             String timeString = argMultimap.getValue(PREFIX_FRIDAY_DISMISSAL).get();
-            if (!timeString.equals("")) {
+            if (!timeString.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new FridayDismissalPredicate(getTimeFromString(timeString)));
             }
@@ -124,7 +126,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             String idValue = argMultimap.getValue(PREFIX_ID).get();
-            if (!idValue.equals("")) {
+            if (!idValue.isEmpty()) {
                 checkEmptyString = false;
                 predicates.add(new IdMatchesPredicate(idValue));
             }

--- a/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/canoe/logic/parser/FindCommandParser.java
@@ -130,6 +130,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             String idValue = argMultimap.getValue(PREFIX_ID).get();
             if (!idValue.isEmpty()) {
                 checkEmptyString = false;
+                ParserUtil.parseId(idValue);
                 predicates.add(new IdMatchesPredicate(idValue));
             }
         }

--- a/src/main/java/seedu/canoe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/canoe/logic/parser/ParserUtil.java
@@ -15,6 +15,7 @@ import seedu.canoe.commons.util.StringUtil;
 import seedu.canoe.logic.parser.exceptions.ParseException;
 import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.Email;
+import seedu.canoe.model.student.Id;
 import seedu.canoe.model.student.Name;
 import seedu.canoe.model.student.Phone;
 import seedu.canoe.model.student.time.Day;
@@ -178,5 +179,20 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code String id} into an {@code Id}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * * @throws ParseException if the given {@code id} is invalid.
+     */
+    public static Id parseId(String id) throws ParseException {
+        requireNonNull(id);
+        String trimmedId = id.trim();
+        if (!Id.isValidId(trimmedId)) {
+            throw new ParseException(Id.MESSAGE_CONSTRAINTS);
+        }
+        return new Id(trimmedId);
     }
 }

--- a/src/main/java/seedu/canoe/model/student/AcademicYearMatchesPredicate.java
+++ b/src/main/java/seedu/canoe/model/student/AcademicYearMatchesPredicate.java
@@ -6,23 +6,23 @@ import java.util.function.Predicate;
  * Tests that a {@code Student}'s {@code AcademicYear} value matches the value given.
  */
 public class AcademicYearMatchesPredicate implements Predicate<Student> {
-    private final String academicYearValue;
+    private final AcademicYear year;
 
-    public AcademicYearMatchesPredicate(String academicYearValue) {
-        this.academicYearValue = academicYearValue;
+    public AcademicYearMatchesPredicate(AcademicYear year) {
+        this.year = year;
     }
 
 
     @Override
     public boolean test(Student student) {
-        return student.getAcademicYear().value.equals(academicYearValue);
+        return student.getAcademicYear().equals(year);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AcademicYearMatchesPredicate // instanceof handles nulls
-                && academicYearValue.equals(((AcademicYearMatchesPredicate) other).academicYearValue)); // state check
+                && year.equals(((AcademicYearMatchesPredicate) other).year)); // state check
     }
 
 }

--- a/src/main/java/seedu/canoe/model/student/Id.java
+++ b/src/main/java/seedu/canoe/model/student/Id.java
@@ -11,10 +11,10 @@ import seedu.canoe.commons.util.StringUtil;
  * Represents a Student's id in the canoe coach book.
  */
 public class Id {
-    public static final String MESSAGE_CONSTRAINTS = "Id must be numeric and unique.";
+    public static final String MESSAGE_CONSTRAINTS = "Id must be numeric with no leading zero, and greater than zero.";
 
     /** validates if the string is numeric */
-    public static final String VALIDATION_REGEX = "-?\\d+(\\.\\d+)?";
+    public static final String VALIDATION_REGEX = "^[1-9][0-9]*$";
 
     /** placeholder value */
     public static final String PLACEHOLDER_VALUE = "0";

--- a/src/main/java/seedu/canoe/model/student/PhoneMatchesPredicate.java
+++ b/src/main/java/seedu/canoe/model/student/PhoneMatchesPredicate.java
@@ -6,22 +6,22 @@ import java.util.function.Predicate;
  * Tests that a {@code Student}'s {@code Phone} value matches the value given.
  */
 public class PhoneMatchesPredicate implements Predicate<Student> {
-    private final String phoneValue;
+    private final Phone phone;
 
-    public PhoneMatchesPredicate(String phoneValue) {
-        this.phoneValue = phoneValue;
+    public PhoneMatchesPredicate(Phone phone) {
+        this.phone = phone;
     }
 
     @Override
     public boolean test(Student student) {
-        return student.getPhone().value.equals(phoneValue);
+        return student.getPhone().equals(phone);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof PhoneMatchesPredicate // instanceof handles nulls
-                && phoneValue.equals(((PhoneMatchesPredicate) other).phoneValue)); // state check
+                && phone.equals(((PhoneMatchesPredicate) other).phone)); // state check
     }
 
 }

--- a/src/main/java/seedu/canoe/model/training/Training.java
+++ b/src/main/java/seedu/canoe/model/training/Training.java
@@ -120,7 +120,7 @@ public class Training {
      * @return true if student id is present inside of training schedule.
      */
     public boolean hasStudentId(String studentId) {
-        return getStudents().stream().map(student -> student.getId()).anyMatch(id -> id.getValue().equals(studentId));
+        return getStudents().stream().map(Student::getId).anyMatch(id -> id.getValue().equals(studentId));
     }
 
     /**

--- a/src/test/java/seedu/canoe/logic/commands/CommonTimeCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/CommonTimeCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import seedu.canoe.model.Model;
 import seedu.canoe.model.ModelManager;
 import seedu.canoe.model.UserPrefs;
+import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
@@ -34,9 +35,8 @@ class CommonTimeCommandTest {
     public void execute_zeroKeywords_defaultDismissalTimes() {
         String expectedMessage = "Search result matches no students!";
         NameContainsKeywordsPredicate namePredicate = preparePredicate(" ");
-        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate(" ");
         AnyMatchPredicateList predicateList = new AnyMatchPredicateList(
-                Arrays.asList(namePredicate, academicYearPredicate)
+                Arrays.asList(namePredicate)
         );
         CommonTimeCommand command = new CommonTimeCommand(predicateList);
         expectedModel.updateFilteredStudentList(predicateList);
@@ -72,7 +72,8 @@ class CommonTimeCommandTest {
     public void execute_oneAcademicYearKeyword_matchedAcademicYearLatestDismissalTimes() {
         String expectedMessage = "Monday: 15:00\n"
                 + "Tuesday: 16:23\n" + "Wednesday: 15:00\n" + "Thursday: 17:00\n" + "Friday: 15:00";
-        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate("1");
+        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate(
+                new AcademicYear("1"));
         AnyMatchPredicateList predicateList = new AnyMatchPredicateList(Arrays.asList(academicYearPredicate));
         CommonTimeCommand command = new CommonTimeCommand(predicateList);
         expectedModel.updateFilteredStudentList(predicateList);
@@ -85,7 +86,8 @@ class CommonTimeCommandTest {
         String expectedMessage = "Monday: 15:00\n"
                 + "Tuesday: 16:23\n" + "Wednesday: 15:00\n" + "Thursday: 17:00\n" + "Friday: 15:00";
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Alice Kunz");
-        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate("1");
+        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate(
+                new AcademicYear("1"));
         AnyMatchPredicateList predicateList = new AnyMatchPredicateList(
                 Arrays.asList(namePredicate, academicYearPredicate)
         );
@@ -100,7 +102,8 @@ class CommonTimeCommandTest {
         String expectedMessage = "Monday: 15:00\n"
                 + "Tuesday: 16:23\n" + "Wednesday: 17:45\n" + "Thursday: 17:00\n" + "Friday: 17:12";
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Daniel Best");
-        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate("1");
+        AcademicYearMatchesPredicate academicYearPredicate = new AcademicYearMatchesPredicate(
+                new AcademicYear("1"));
         AnyMatchPredicateList predicateList = new AnyMatchPredicateList(
                 Arrays.asList(namePredicate, academicYearPredicate)
         );

--- a/src/test/java/seedu/canoe/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/FindCommandTest.java
@@ -21,6 +21,7 @@ import seedu.canoe.model.ModelManager;
 import seedu.canoe.model.UserPrefs;
 import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
+import seedu.canoe.model.student.Phone;
 import seedu.canoe.model.student.PhoneMatchesPredicate;
 
 /**
@@ -37,9 +38,9 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondNamePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
         PhoneMatchesPredicate firstPhonePredicate =
-                new PhoneMatchesPredicate("12345678");
+                new PhoneMatchesPredicate(new Phone("12345678"));
         PhoneMatchesPredicate secondPhonePredicate =
-                new PhoneMatchesPredicate("87654321");
+                new PhoneMatchesPredicate(new Phone("87654321"));
         AllMatchPredicateList firstAllMatchPredicateList =
                 new AllMatchPredicateList(Arrays.asList(firstNamePredicate, firstPhonePredicate));
         AllMatchPredicateList secondAllMatchPredicateList =
@@ -69,9 +70,8 @@ public class FindCommandTest {
     public void execute_zeroKeywords_noStudentFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate namePredicate = preparePredicate(" ");
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(" ");
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
-                Arrays.asList(namePredicate, phonePredicate)
+                Arrays.asList(namePredicate)
         );
         FindCommand command = new FindCommand(allMatchPredicateList);
         expectedModel.updateFilteredStudentList(allMatchPredicateList);
@@ -93,7 +93,7 @@ public class FindCommandTest {
     @Test
     public void execute_phoneKeyword_oneStudentFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("9482224");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("9482224"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(phonePredicate));
         FindCommand command = new FindCommand(allMatchPredicateList);
         expectedModel.updateFilteredStudentList(allMatchPredicateList);
@@ -105,7 +105,7 @@ public class FindCommandTest {
     public void execute_multipleKeywords_oneStudentFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Kurz Elle Kunz");
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("9482427");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("9482427"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
                 Arrays.asList(namePredicate, phonePredicate)
         );
@@ -119,7 +119,7 @@ public class FindCommandTest {
     public void execute_multipleKeywords_noStudentFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Kurz Elle Kunz");
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("1234567");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("1234567"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
                 Arrays.asList(namePredicate, phonePredicate)
         );

--- a/src/test/java/seedu/canoe/logic/parser/CanoeCoachParserTest.java
+++ b/src/test/java/seedu/canoe/logic/parser/CanoeCoachParserTest.java
@@ -27,6 +27,7 @@ import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.IdMatchesPredicate;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
+import seedu.canoe.model.student.Phone;
 import seedu.canoe.model.student.PhoneMatchesPredicate;
 import seedu.canoe.model.student.Student;
 import seedu.canoe.testutil.EditStudentDescriptorBuilder;
@@ -82,7 +83,7 @@ public class CanoeCoachParserTest {
                         + " p/123456");
         assertEquals(new FindCommand(new AllMatchPredicateList(Arrays.asList(
                 new NameContainsKeywordsPredicate(Arrays.asList("foo", "bar", "baz")),
-                new PhoneMatchesPredicate("123456")))), command);
+                new PhoneMatchesPredicate(new Phone("123456"))))), command);
     }
 
     @Test

--- a/src/test/java/seedu/canoe/logic/parser/CommonTimeCommandParserTest.java
+++ b/src/test/java/seedu/canoe/logic/parser/CommonTimeCommandParserTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.canoe.logic.commands.CommonTimeCommand;
+import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
 import seedu.canoe.model.student.AnyMatchPredicateList;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
@@ -22,17 +23,17 @@ class CommonTimeCommandParserTest {
         CommonTimeCommand firstExpectedCommonTimeCommand =
                 new CommonTimeCommand(AnyMatchPredicateList.of(
                         new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new AcademicYearMatchesPredicate("123456")
+                        new AcademicYearMatchesPredicate(new AcademicYear("3"))
                 ));
-        assertParseSuccess(parser, " n/Alice Bob ay/123456", firstExpectedCommonTimeCommand);
+        assertParseSuccess(parser, " n/Alice Bob ay/3", firstExpectedCommonTimeCommand);
 
         // multiple whitespaces between keywords
         CommonTimeCommand secondExpectedCommonTimeCommand =
                 new CommonTimeCommand(AnyMatchPredicateList.of(
                         new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new AcademicYearMatchesPredicate("85355255")
+                        new AcademicYearMatchesPredicate(new AcademicYear("3"))
                 ));
-        assertParseSuccess(parser, "  \n  \t n/Alice Bob \t \n \n ay/85355255", secondExpectedCommonTimeCommand);
+        assertParseSuccess(parser, "  \n  \t n/Alice Bob \t \n \n ay/3", secondExpectedCommonTimeCommand);
     }
 
     @Test
@@ -43,8 +44,8 @@ class CommonTimeCommandParserTest {
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
         CommonTimeCommand expectedCommonTimeCommand = new CommonTimeCommand(AnyMatchPredicateList.of(
-                new AcademicYearMatchesPredicate("3")
+                new AcademicYearMatchesPredicate(new AcademicYear("3"))
         ));
-        assertParseSuccess(parser, " ay/11111111 ay/22222222 ay/3", expectedCommonTimeCommand);
+        assertParseSuccess(parser, " ay/1 ay/2 ay/3", expectedCommonTimeCommand);
     }
 }

--- a/src/test/java/seedu/canoe/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/canoe/logic/parser/FindCommandParserTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.canoe.logic.commands.FindCommand;
+import seedu.canoe.model.student.AcademicYear;
 import seedu.canoe.model.student.AcademicYearMatchesPredicate;
 import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.EmailContainsKeywordPredicate;
@@ -43,7 +44,7 @@ public class FindCommandParserTest {
         FindCommand thirdExpectedFindCommand =
                 new FindCommand(AllMatchPredicateList.of(
                         new EmailContainsKeywordPredicate("meow"),
-                        new AcademicYearMatchesPredicate("2"),
+                        new AcademicYearMatchesPredicate(new AcademicYear("2")),
                         new IdMatchesPredicate("1")
                 ));
         assertParseSuccess(parser, " e/meow ay/2 id/1", thirdExpectedFindCommand);

--- a/src/test/java/seedu/canoe/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/canoe/logic/parser/FindCommandParserTest.java
@@ -13,6 +13,7 @@ import seedu.canoe.model.student.AllMatchPredicateList;
 import seedu.canoe.model.student.EmailContainsKeywordPredicate;
 import seedu.canoe.model.student.IdMatchesPredicate;
 import seedu.canoe.model.student.NameContainsKeywordsPredicate;
+import seedu.canoe.model.student.Phone;
 import seedu.canoe.model.student.PhoneMatchesPredicate;
 import seedu.canoe.model.student.time.Day;
 
@@ -26,7 +27,7 @@ public class FindCommandParserTest {
         FindCommand firstExpectedFindCommand =
                 new FindCommand(AllMatchPredicateList.of(
                         new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new PhoneMatchesPredicate("123456")
+                        new PhoneMatchesPredicate(new Phone("123456"))
                 ));
         assertParseSuccess(parser, " n/Alice Bob p/123456", firstExpectedFindCommand);
 
@@ -34,7 +35,7 @@ public class FindCommandParserTest {
         FindCommand secondExpectedFindCommand =
                 new FindCommand(AllMatchPredicateList.of(
                         new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new PhoneMatchesPredicate("85355255")
+                        new PhoneMatchesPredicate(new Phone("85355255"))
                 ));
         assertParseSuccess(parser, "  \n  \t n/Alice Bob \t \n \n p/85355255", secondExpectedFindCommand);
 
@@ -66,7 +67,7 @@ public class FindCommandParserTest {
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
         FindCommand expectedFindCommand = new FindCommand(AllMatchPredicateList.of(
-                new PhoneMatchesPredicate("33333333")
+                new PhoneMatchesPredicate(new Phone("33333333"))
         ));
         assertParseSuccess(parser, " p/11111111 p/22222222 p/33333333", expectedFindCommand);
     }

--- a/src/test/java/seedu/canoe/model/student/AcademicYearMatchesPredicateTest.java
+++ b/src/test/java/seedu/canoe/model/student/AcademicYearMatchesPredicateTest.java
@@ -14,14 +14,14 @@ class AcademicYearMatchesPredicateTest {
         String firstYear = "1";
         String secondYear = "2";
 
-        AcademicYearMatchesPredicate firstPredicate = new AcademicYearMatchesPredicate(firstYear);
-        AcademicYearMatchesPredicate secondPredicate = new AcademicYearMatchesPredicate(secondYear);
+        AcademicYearMatchesPredicate firstPredicate = new AcademicYearMatchesPredicate(new AcademicYear(firstYear));
+        AcademicYearMatchesPredicate secondPredicate = new AcademicYearMatchesPredicate(new AcademicYear(secondYear));
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        AcademicYearMatchesPredicate firstPredicateCopy = new AcademicYearMatchesPredicate(firstYear);
+        AcademicYearMatchesPredicate firstPredicateCopy = new AcademicYearMatchesPredicate(new AcademicYear(firstYear));
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -36,13 +36,13 @@ class AcademicYearMatchesPredicateTest {
 
     @Test
     void test_yearMatches_returnsTrue() {
-        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate("3");
+        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate(new AcademicYear("3"));
         assertTrue(predicate.test(new StudentBuilder().withAcademicYear("3").build()));
     }
 
     @Test
     void test_yearDoesNotMatch_returnsFalse() {
-        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate("3");
+        AcademicYearMatchesPredicate predicate = new AcademicYearMatchesPredicate(new AcademicYear("3"));
         assertFalse(predicate.test(new StudentBuilder().withAcademicYear("1").build()));
         assertFalse(predicate.test(new StudentBuilder().withAcademicYear("2").build()));
     }

--- a/src/test/java/seedu/canoe/model/student/AllMatchPredicateListTest.java
+++ b/src/test/java/seedu/canoe/model/student/AllMatchPredicateListTest.java
@@ -18,10 +18,10 @@ class AllMatchPredicateListTest {
     public void equals() {
         NameContainsKeywordsPredicate firstNamePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        PhoneMatchesPredicate firstPhonePredicate = new PhoneMatchesPredicate("123");
+        PhoneMatchesPredicate firstPhonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         NameContainsKeywordsPredicate secondNamePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
-        PhoneMatchesPredicate secondPhonePredicate = new PhoneMatchesPredicate("321");
+        PhoneMatchesPredicate secondPhonePredicate = new PhoneMatchesPredicate(new Phone("321"));
         List<Predicate<Student>> firstListOfPredicates = Arrays.asList(firstNamePredicate, firstPhonePredicate);
         List<Predicate<Student>> secondListOfPredicates = Arrays.asList(secondNamePredicate, secondPhonePredicate);
         AllMatchPredicateList firstAllMatchPredicateList = new AllMatchPredicateList(firstListOfPredicates);
@@ -89,21 +89,16 @@ class AllMatchPredicateListTest {
 
     @Test
     public void test_studentContainsPhoneValue_returnsTrue() {
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("123");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(phonePredicate));
         assertTrue(allMatchPredicateList.test(new StudentBuilder().withPhone("123").build()));
     }
 
     @Test
     public void test_studentDoesNotContainPhoneValue_returnsFalse() {
-        // No value
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("");
-        AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(phonePredicate));
-        assertFalse(allMatchPredicateList.test(new StudentBuilder().withName("Alice").build()));
-
         // Non-matching value
-        phonePredicate = new PhoneMatchesPredicate("123");
-        allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(phonePredicate));
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
+        AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(phonePredicate));
         assertFalse(allMatchPredicateList.test(new StudentBuilder().withPhone("321").build()));
     }
 
@@ -112,7 +107,7 @@ class AllMatchPredicateListTest {
         // One name keyword one phone value
         NameContainsKeywordsPredicate namePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("123");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
                 Arrays.asList(namePredicate, phonePredicate)
         );
@@ -120,7 +115,7 @@ class AllMatchPredicateListTest {
 
         // Multiple name keywords one phone value
         namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        phonePredicate = new PhoneMatchesPredicate("456789");
+        phonePredicate = new PhoneMatchesPredicate(new Phone("456789"));
         allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(namePredicate, phonePredicate));
         assertTrue(allMatchPredicateList.test(new StudentBuilder().withName("Bob").withPhone("456789").build()));
     }
@@ -130,7 +125,7 @@ class AllMatchPredicateListTest {
         // Does not contain one name keyword, contains one phone value
         NameContainsKeywordsPredicate namePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("123");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
                 Arrays.asList(namePredicate, phonePredicate)
         );
@@ -138,19 +133,19 @@ class AllMatchPredicateListTest {
 
         // Does not contain multiple name keywords, contains one phone value
         namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        phonePredicate = new PhoneMatchesPredicate("456789");
+        phonePredicate = new PhoneMatchesPredicate(new Phone("456789"));
         allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(namePredicate, phonePredicate));
         assertFalse(allMatchPredicateList.test(new StudentBuilder().withName("Alice").withPhone("456789").build()));
 
         // Contains one name keyword, does not contain phone value
         namePredicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
-        phonePredicate = new PhoneMatchesPredicate("123");
+        phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(namePredicate, phonePredicate));
         assertFalse(allMatchPredicateList.test(new StudentBuilder().withName("Alice").withPhone("456").build()));
 
         // Contains multiple name keywords, does not contain phone value
         namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        phonePredicate = new PhoneMatchesPredicate("456789");
+        phonePredicate = new PhoneMatchesPredicate(new Phone("456789"));
         allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(namePredicate, phonePredicate));
         assertFalse(allMatchPredicateList.test(new StudentBuilder().withName("Carol").withPhone("123").build()));
     }
@@ -160,7 +155,7 @@ class AllMatchPredicateListTest {
         // One name keyword one phone value
         NameContainsKeywordsPredicate namePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
-        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate("123");
+        PhoneMatchesPredicate phonePredicate = new PhoneMatchesPredicate(new Phone("123"));
         AllMatchPredicateList allMatchPredicateList = new AllMatchPredicateList(
                 Arrays.asList(namePredicate, phonePredicate)
         );
@@ -168,7 +163,7 @@ class AllMatchPredicateListTest {
 
         // Multiple name keywords one phone value
         namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        phonePredicate = new PhoneMatchesPredicate("456789");
+        phonePredicate = new PhoneMatchesPredicate(new Phone("456789"));
         allMatchPredicateList = new AllMatchPredicateList(Arrays.asList(namePredicate, phonePredicate));
         assertFalse(allMatchPredicateList.test(new StudentBuilder().withName("Boo").withPhone("123").build()));
     }

--- a/src/test/java/seedu/canoe/model/student/PhoneMatchesPredicateTest.java
+++ b/src/test/java/seedu/canoe/model/student/PhoneMatchesPredicateTest.java
@@ -14,14 +14,14 @@ class PhoneMatchesPredicateTest {
         String firstPredicateValue = "123";
         String secondPredicateValue = "987";
 
-        PhoneMatchesPredicate firstPredicate = new PhoneMatchesPredicate(firstPredicateValue);
-        PhoneMatchesPredicate secondPredicate = new PhoneMatchesPredicate(secondPredicateValue);
+        PhoneMatchesPredicate firstPredicate = new PhoneMatchesPredicate(new Phone(firstPredicateValue));
+        PhoneMatchesPredicate secondPredicate = new PhoneMatchesPredicate(new Phone(secondPredicateValue));
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        PhoneMatchesPredicate firstPredicateCopy = new PhoneMatchesPredicate(firstPredicateValue);
+        PhoneMatchesPredicate firstPredicateCopy = new PhoneMatchesPredicate(new Phone(firstPredicateValue));
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -36,18 +36,14 @@ class PhoneMatchesPredicateTest {
 
     @Test
     public void test_phoneValueContainsKeywords_returnsTrue() {
-        PhoneMatchesPredicate predicate = new PhoneMatchesPredicate("123456");
+        PhoneMatchesPredicate predicate = new PhoneMatchesPredicate(new Phone("123456"));
         assertTrue(predicate.test(new StudentBuilder().withPhone("123456").build()));
     }
 
     @Test
     public void test_phoneValueDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        PhoneMatchesPredicate predicate = new PhoneMatchesPredicate("");
-        assertFalse(predicate.test(new StudentBuilder().withPhone("65423112").build()));
-
         // Non-matching keyword
-        predicate = new PhoneMatchesPredicate("123675678");
+        PhoneMatchesPredicate predicate = new PhoneMatchesPredicate(new Phone("123675678"));
         assertFalse(predicate.test(new StudentBuilder().withName("987654321").build()));
 
     }


### PR DESCRIPTION
**FindCommandParser ensures valid input for the following**
* Phone - `find p/1` is no longer valid
* AcademicYear - `find ay/6` is no longer valid
* Id - `find id/lmao10` is no longer valid

Email and Name still takes in raw string inputs because our find method searches for string containment, not exact string matching. Note that Phone, AcademicYear, and Id find are all matching by exact, hence the need for valid input check.
<br>

**Id regex and constraint message**
* Id constraint is now: Must be numeric, no leading zero, and greater than zero
   * E.g. Invalid values: `001`, `1a`, `-1`, `0`, `abc`
   * E.g. Valid values: `1`, `50`, `1000`
* Note that this is only relevant to developer guide and implementation, users are only able to input Id values via the `find` command.