### PR TITLE
Update mark unmark attendance

### DIFF
--- a/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
@@ -7,6 +7,7 @@ import static seedu.canoe.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import seedu.canoe.commons.core.LogsCenter;
 import seedu.canoe.commons.core.index.Index;
@@ -29,8 +30,8 @@ public class MarkAttendanceCommand extends Command {
             + "Example: " + COMMAND_WORD + " 2 id/1,4,19";
 
     public static final String MESSAGE_NO_STUDENTS_SPECIFIED = "At least one student to be marked must be specified.";
-    public static final String MESSAGE_INVALID_STUDENT_MARKED = "Some students do not have specified"
-            + " training session scheduled!";
+    public static final String MESSAGE_INVALID_STUDENT_MARKED = "These students do not have the specified"
+            + " training session scheduled: %1$s!";
     public static final String MESSAGE_MARK_ATTENDANCE_SUCCESS = "Marked these students for their attendance: %1$s!";
 
     private final Index trainingIndex;
@@ -73,10 +74,11 @@ public class MarkAttendanceCommand extends Command {
         Attendance markedAttendance = new Attendance(training.getDateTime());
         markedAttendance.marks();
 
-        if (!studentsHaveAttendance(unmarkedAttendance, attendedStudents)) {
+        List<Student> studentsNoAttendance = studentsWithNoAttendance(unmarkedAttendance, attendedStudents);
+        if (!studentsNoAttendance.isEmpty()) {
             LOGGER.warning("Some students do not contain training session");
             model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-            throw new CommandException(MESSAGE_INVALID_STUDENT_MARKED);
+            throw new CommandException(String.format(MESSAGE_INVALID_STUDENT_MARKED, getStudentIdsAsString(studentsNoAttendance)));
         }
 
         for (Student student : attendedStudents) {
@@ -96,20 +98,19 @@ public class MarkAttendanceCommand extends Command {
     }
 
     /**
-     * Checks the list of students and returns whether all the students have the attendance.
+     * Checks the list of students and returns a list of students who do not have the attendance.
      *
      * @param attendance to be checked for.
      * @param studentsToCheck list of students to check.
-     * @return true if students have training session scheduled, false if otherwise.
+     * @return list of students who do not have training session scheduled.
      */
-    public boolean studentsHaveAttendance(Attendance attendance, List<Student> studentsToCheck) {
+    public List<Student> studentsWithNoAttendance(Attendance attendance, List<Student> studentsToCheck) {
         assert attendance != null;
-        for (Student student: studentsToCheck) {
-            if (!student.containsAttendance(attendance)) {
-                return false;
-            }
-        }
-        return true;
+        List<Student> studentsNoAttendance = studentsToCheck.stream()
+                .filter(student -> !student.containsAttendance(attendance))
+                .collect(Collectors.toList());
+
+        return studentsNoAttendance;
     }
 
     /**

--- a/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
@@ -75,7 +75,8 @@ public class MarkAttendanceCommand extends Command {
 
         if (!studentsHaveAttendance(unmarkedAttendance, attendedStudents)) {
             LOGGER.warning("Some students do not contain training session");
-            return new CommandResult(MESSAGE_INVALID_STUDENT_MARKED);
+            model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+            throw new CommandException(MESSAGE_INVALID_STUDENT_MARKED);
         }
 
         for (Student student : attendedStudents) {

--- a/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/MarkAttendanceCommand.java
@@ -78,7 +78,9 @@ public class MarkAttendanceCommand extends Command {
         if (!studentsNoAttendance.isEmpty()) {
             LOGGER.warning("Some students do not contain training session");
             model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-            throw new CommandException(String.format(MESSAGE_INVALID_STUDENT_MARKED, getStudentIdsAsString(studentsNoAttendance)));
+            throw new CommandException(String.format(
+                    MESSAGE_INVALID_STUDENT_MARKED, getStudentIdsAsString(studentsNoAttendance))
+            );
         }
 
         for (Student student : attendedStudents) {

--- a/src/main/java/seedu/canoe/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/UnmarkAttendanceCommand.java
@@ -76,7 +76,8 @@ public class UnmarkAttendanceCommand extends Command {
 
         if (!studentsHaveAttendance(unmarkedAttendance, attendedStudents)) {
             LOGGER.warning("Some students do not contain training session");
-            return new CommandResult(MESSAGE_INVALID_STUDENT_UNMARKED);
+            model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+            throw new CommandException(MESSAGE_INVALID_STUDENT_UNMARKED);
         }
 
         for (Student student : attendedStudents) {

--- a/src/main/java/seedu/canoe/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/canoe/logic/commands/UnmarkAttendanceCommand.java
@@ -79,7 +79,9 @@ public class UnmarkAttendanceCommand extends Command {
         if (!studentsNoAttendance.isEmpty()) {
             LOGGER.warning("Some students do not contain training session");
             model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-            throw new CommandException(String.format(MESSAGE_INVALID_STUDENT_UNMARKED, getStudentIdsAsString(studentsNoAttendance)));
+            throw new CommandException(String.format(
+                    MESSAGE_INVALID_STUDENT_UNMARKED, getStudentIdsAsString(studentsNoAttendance))
+            );
         }
 
         for (Student student : attendedStudents) {

--- a/src/test/java/seedu/canoe/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/MarkAttendanceCommandTest.java
@@ -55,8 +55,8 @@ class MarkAttendanceCommandTest {
 
     @Test
     void execute_validParams_commandFailure() {
-        String expectedMessage = "Some students do not have specified"
-                + " training session scheduled!";
+        String expectedMessage = "These students do not have the specified"
+                + " training session scheduled: 1 4!";
         IdMatchesPredicate firstIdPredicate = new IdMatchesPredicate("1");
         IdMatchesPredicate secondIdPredicate = new IdMatchesPredicate("4");
 

--- a/src/test/java/seedu/canoe/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/MarkAttendanceCommandTest.java
@@ -54,7 +54,7 @@ class MarkAttendanceCommandTest {
     }
 
     @Test
-    void execute_validParams_studentsNotInTrainingMessage() {
+    void execute_validParams_commandFailure() {
         String expectedMessage = "Some students do not have specified"
                 + " training session scheduled!";
         IdMatchesPredicate firstIdPredicate = new IdMatchesPredicate("1");
@@ -66,17 +66,11 @@ class MarkAttendanceCommandTest {
         model.addTraining(firstTraining);
         model.addTraining(secondTraining);
         model.addTraining(thirdTraining);
-        expectedModel.addTraining(firstTraining);
-        expectedModel.addTraining(secondTraining);
-        expectedModel.addTraining(thirdTraining);
-
-        AnyMatchPredicateList predicateList = AnyMatchPredicateList.of(firstIdPredicate, secondIdPredicate);
-        expectedModel.updateFilteredStudentList(predicateList);
 
         Index trainingIndex = INDEX_THIRD_TRAINING;
         MarkAttendanceCommand command = new MarkAttendanceCommand(
                 trainingIndex, AnyMatchPredicateList.of(firstIdPredicate, secondIdPredicate));
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
@@ -66,17 +66,11 @@ class UnmarkAttendanceCommandTest {
         model.addTraining(firstTraining);
         model.addTraining(secondTraining);
         model.addTraining(thirdTraining);
-        expectedModel.addTraining(firstTraining);
-        expectedModel.addTraining(secondTraining);
-        expectedModel.addTraining(thirdTraining);
-
-        AnyMatchPredicateList predicateList = AnyMatchPredicateList.of(firstIdPredicate, secondIdPredicate);
-        expectedModel.updateFilteredStudentList(predicateList);
 
         Index trainingIndex = INDEX_THIRD_TRAINING;
         UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(
                 trainingIndex, AnyMatchPredicateList.of(firstIdPredicate, secondIdPredicate));
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
@@ -55,8 +55,8 @@ class UnmarkAttendanceCommandTest {
 
     @Test
     void execute_validParams_commandFailure() {
-        String expectedMessage = "Some students do not have specified"
-                + " training session scheduled!";
+        String expectedMessage = "These students do not have the specified"
+                + " training session scheduled: 1 4!";
         IdMatchesPredicate firstIdPredicate = new IdMatchesPredicate("1");
         IdMatchesPredicate secondIdPredicate = new IdMatchesPredicate("4");
 

--- a/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/canoe/logic/commands/UnmarkAttendanceCommandTest.java
@@ -54,7 +54,7 @@ class UnmarkAttendanceCommandTest {
     }
 
     @Test
-    void execute_validParams_studentsNotInTrainingMessage() {
+    void execute_validParams_commandFailure() {
         String expectedMessage = "Some students do not have specified"
                 + " training session scheduled!";
         IdMatchesPredicate firstIdPredicate = new IdMatchesPredicate("1");


### PR DESCRIPTION
- Refactor both mark and unmark attendance command to throw a command exception instead of sending a commandresult if there are students that do not have the specified training session in their schedule.
- Update the error message for both mark and unmark attendance command to indicate which student(s) does not have the training session scheduled.